### PR TITLE
Pass request to django's authenticate

### DIFF
--- a/changelog.d/14.bugfix.md
+++ b/changelog.d/14.bugfix.md
@@ -1,0 +1,1 @@
+Pass `request` to `django.contrib.auth.authenticate`.

--- a/src/rest_framework_jwt/serializers.py
+++ b/src/rest_framework_jwt/serializers.py
@@ -82,7 +82,7 @@ class JSONWebTokenSerializer(serializers.Serializer):
             'password': data.get('password')
         }
 
-        user = authenticate(**credentials)
+        user = authenticate(self.context['request'], **credentials)
 
         if not user:
             msg = _('Unable to log in with provided credentials.')


### PR DESCRIPTION
Ciao,
MR to fix upstream issue: https://github.com/jpadilla/django-rest-framework-jwt/issues/455
Also django-axes requires request in authenticate
"RequestParameterRequired: AxesModelBackend requires calls to authenticate to pass `request` as an argument."