### PR TITLE
Use pk to get profile's id in jwt_create_payload

### DIFF
--- a/changelog.d/15.bugfix.md
+++ b/changelog.d/15.bugfix.md
@@ -1,0 +1,1 @@
+Use pk to get profile's id in `rest_framework_jwt.utils.jwt_create_payload`.

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -66,7 +66,7 @@ def jwt_create_payload(user):
     # If you have some other implementation feel free to create your own
     # `jwt_create_payload` method with custom payload.
     if hasattr(user, 'profile'):
-        payload['user_profile_id'] = user.profile.id if user.profile else None,
+        payload['user_profile_id'] = user.profile.pk if user.profile else None,
 
     # Include original issued at time for a brand new token
     # to allow token refresh


### PR DESCRIPTION
When someone uses other primary key then `id` in user.profile, `jwt_create_payload` raises exception.
.pk should be used in favor of .id