### PR TITLE
Remove 310 from not supported python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     docs,
-    py{27,34,35,36}-dj111-drf{37,38,39,310}-codecov
-    py{34,35,36,37}-dj20-drf{37,38,39,310}-codecov
+    py{27,34,35,36}-dj111-drf{37,38,39}-codecov
+    py{34,35,36,37}-dj20-drf{37,38,39}-codecov
     py{35,36,37}-dj21-drf{37,38,39,310}-codecov
     py{35,36,37}-dj22-drf{37,38,39,310}-codecov
 


### PR DESCRIPTION
I'm sorry I forgot to check drf's 3.10 supported python versions