### PR TITLE
Allow a setting to omit the user_id from the token payload

### DIFF
--- a/changelog.d/20.feature.md
+++ b/changelog.d/20.feature.md
@@ -1,0 +1,1 @@
+Allow control of setting the `user_id` in the payload with `JWT_PAYLOAD_INCLUDE_USER_ID`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -149,6 +149,7 @@ JWT_AUTH = {
         'rest_framework_jwt.utils.jwt_create_payload',
     'JWT_PAYLOAD_GET_USERNAME_HANDLER':
         'rest_framework_jwt.utils.jwt_get_username_from_payload_handler',
+    'JWT_PAYLOAD_INCLUDE_USER_ID': True,
     'JWT_VERIFY': True,
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_LEEWAY': 0,
@@ -221,6 +222,12 @@ Specify a custom function to generate the token payload
 ### JWT_PAYLOAD_GET_USERNAME_HANDLER
 
 If you store `username` differently than the default payload handler does, implement this function to fetch `username` from the payload.
+
+### JWT_PAYLOAD_INCLUDE_USER_ID
+
+If you do not wish to include the user's primary key (typically `id`) in the token payload, then set this to `False`.
+
+Default is `True`.
 
 ### JWT_VERIFY
 

--- a/src/rest_framework_jwt/settings.py
+++ b/src/rest_framework_jwt/settings.py
@@ -27,6 +27,7 @@ DEFAULTS = {
         'rest_framework_jwt.utils.jwt_create_payload',
     'JWT_PAYLOAD_GET_USERNAME_HANDLER':
         'rest_framework_jwt.utils.jwt_get_username_from_payload_handler',
+    'JWT_PAYLOAD_INCLUDE_USER_ID': True,
     'JWT_VERIFY': True,
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_LEEWAY': 0,

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -56,11 +56,13 @@ def jwt_create_payload(user):
     expiration_time = issued_at_time + api_settings.JWT_EXPIRATION_DELTA
 
     payload = {
-        'user_id': user.pk,
         'username': user.get_username(),
         'iat': unix_epoch(issued_at_time),
         'exp': expiration_time
     }
+
+    if api_settings.JWT_PAYLOAD_INCLUDE_USER_ID:
+        payload['user_id'] = user.pk
 
     # It's common practice to have user object attached to profile objects.
     # If you have some other implementation feel free to create your own


### PR DESCRIPTION
The default value preserves the current behaviour. Perhaps in a future version, you may want to make the default to not include it, but that would naturally be a breaking change.

As far as I can tell, the default behaviour doesn't use this value to look up the user, so omitting it should generally be safe (unless an application is relying on it when using the token).

In my particular case, this primary key is a serial number, which I would prefer not to leak to the outside world.