### PR TITLE
Remove second response serializaton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ python_boilerplate/
 # Sqlite3
 *.sqlite3
 
+# virtual environment stuff
+venv/
+.python-version

--- a/changelog.d/22.bugfix.md
+++ b/changelog.d/22.bugfix.md
@@ -1,0 +1,6 @@
+Remove serialization on response data in `BaseJSONWebTokenAPIView` because it 
+breaks custom response payload handlers which add extra data to the response 
+payload. This change aligns this fork more closely with the original and makes 
+it easier to use this fork as a drop-in replacement for the original. Also 
+change the ReponsePayload from a `namedtuple` to a dictionary because 
+`namedtuple` is not JSON serializable 

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -130,9 +130,4 @@ def jwt_create_response_payload(
     Note that we are using `pk` field here - this is for forward compatibility
     with drf add-ons that might require `pk` field in order (eg. jsonapi).
     """
-
-    response_payload = namedtuple('ResponsePayload', 'pk token')
-    response_payload.pk = issued_at
-    response_payload.token = token
-
-    return response_payload
+    return {'pk': issued_at, 'token': token}

--- a/src/rest_framework_jwt/views.py
+++ b/src/rest_framework_jwt/views.py
@@ -37,10 +37,7 @@ class BaseJSONWebTokenAPIView(GenericAPIView):
         response_data = JSONWebTokenAuthentication. \
             jwt_create_response_payload(token, user, request, issued_at)
 
-        response_serializer = self.get_serializer(
-            response_data, context={'request': request}
-        )
-        response = Response(response_serializer.data)
+        response = Response(response_data)
 
         if api_settings.JWT_AUTH_COOKIE:
             expiration = (


### PR DESCRIPTION
Remove the second response serialization because it breaks custom
response payload handlers. Fixes #10