### PR TITLE
Document compatibility with Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to know more about JWT, check out the following resources:
 
 ## Requirements
 
--  Python 2.7, 3.4, 3.5, 3.6
+-  Python 2.7, 3.4, 3.5, 3.6, 3.7
 -  Django 1.11, 2.0, 2.1, 2.2
 -  Django REST Framework 3.7+
 

--- a/changelog.d/23.doc.md
+++ b/changelog.d/23.doc.md
@@ -1,0 +1,1 @@
+Document compatibility with Python 3.7.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ If you want to know more about JWT, check out the following resources:
 
 ## Requirements
 
-- Python 2.7, 3.4, 3.5, 3.6
+- Python 2.7, 3.4, 3.5, 3.6, 3.7
 - Django 1.11, 2.0, 2.1, 2.2
 - Django REST Framework 3.7+
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     docs,
-    py{27,34,35,36}-dj111-drf{37,38,39}-codecov
+    py{27,34,35,36,37}-dj111-drf{37,38,39}-codecov
     py{34,35,36,37}-dj20-drf{37,38,39}-codecov
     py{35,36,37}-dj21-drf{37,38,39,310}-codecov
     py{35,36,37}-dj22-drf{37,38,39,310}-codecov


### PR DESCRIPTION
Document that the package supports Python 3.7. Support was added in commit 07a759fdc9a75e8fb8b3387a70ca1b91f2aa8b8d.

Additionally, test Django 1.11 on Python 3.7. Django 1.11 has supported Python 3.7 since [1.11.17](https://docs.djangoproject.com/en/2.2/releases/1.11.17/).