### PR TITLE
change smart_text -> smart_str since deprecation

### DIFF
--- a/changelog.d/28.misc.md
+++ b/changelog.d/28.misc.md
@@ -1,1 +1,1 @@
-changed occurrences of `smart_text` to `smart_str` since it was in Django 3.X
+changed occurrences of `smart_text` to `smart_str` since it was deprecated in Django 3.X

--- a/changelog.d/28.misc.md
+++ b/changelog.d/28.misc.md
@@ -1,0 +1,1 @@
+changed occurrences of `smart_text` to `smart_str` since it was in Django 3.X

--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import jwt
 
 from django.contrib.auth import get_user_model
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
 
 from rest_framework import exceptions
@@ -116,7 +116,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
                 return request.COOKIES.get(api_settings.JWT_AUTH_COOKIE)
             return None
 
-        if smart_text(auth[0].lower()) != auth_header_prefix:
+        if smart_str(auth[0].lower()) != auth_header_prefix:
             return None
 
         if len(auth) == 1:

--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -5,13 +5,13 @@ from __future__ import unicode_literals
 import jwt
 
 from django.contrib.auth import get_user_model
-from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
 
 from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 
 from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.compat import smart_str
 
 
 class JSONWebTokenAuthentication(BaseAuthentication):

--- a/src/rest_framework_jwt/compat.py
+++ b/src/rest_framework_jwt/compat.py
@@ -7,3 +7,9 @@ try:
     from django.urls import include, url
 except ImportError:
     from django.conf.urls import include, url  # noqa: F401
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str as smart_text
+    

--- a/src/rest_framework_jwt/compat.py
+++ b/src/rest_framework_jwt/compat.py
@@ -9,7 +9,7 @@ except ImportError:
     from django.conf.urls import include, url  # noqa: F401
 
 try:
-    from django.utils.encoding import smart_text
+    from django.utils.encoding import smart_str
 except ImportError:
-    from django.utils.encoding import smart_str as smart_text
+    from django.utils.encoding import smart_text as smart_str
     


### PR DESCRIPTION
Using the smart_text function causes lots of these warning messages in the console:
```
/venv/lib/python3.7/site-packages/rest_framework_jwt/authentication.py:90: RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str().
  if smart_text(auth[0].lower()) != auth_header_prefix:
```