### PR TITLE
add JWT_AUTH_COOKIE_* settings paralleling django SESSION_COOKIE_*

### DIFF
--- a/changelog.d/29.feature.md
+++ b/changelog.d/29.feature.md
@@ -1,0 +1,12 @@
+added `JWT_AUTH_COOKIE_*` settings paralleling Django's
+`SESSION_COOKIE_*` which are used for `JWT_AUTH_COOKIE` and
+`JWT_IMPERSONATION_COOKIE`
+
+This changes the default `Secure` attribute from `False` to
+`True`. Users wishing to use JWT cookies over http (as in no TLS/SSL)
+need to set `JWT_AUTH_COOKIE_SECURE` to `False.`
+
+This change is intentional to follow common best common practice.
+
+With Django versions >= 2.1.0, the `Samesite` attribute is set to
+`Lax` by default.

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,10 @@ JWT_AUTH = {
     'JWT_RESPONSE_PAYLOAD_HANDLER':
         'rest_framework_jwt.utils.jwt_create_response_payload',
     'JWT_AUTH_COOKIE': None,
+    'JWT_AUTH_COOKIE_DOMAIN': None,
+    'JWT_AUTH_COOKIE_PATH': '/',
+    'JWT_AUTH_COOKIE_SECURE': True,
+    'JWT_AUTH_COOKIE_SAMESITE': 'Lax',
     'JWT_IMPERSONATION_COOKIE': None,
 }
 ```
@@ -315,11 +319,54 @@ procedure will also look into this cookie, if set. The 'Authorization' header ta
 
 Default is `None` and no cookie is set when creating tokens nor accepted when validating them.
 
+### JWT_AUTH_COOKIE_DOMAIN
+
+Default: `None`
+
+The domain to use for the JWT cookie analogous to
+`SESSION_COOKIE_DOMAIN` for django sessions.
+
+Has no effect unless JWT_AUTH_COOKIE is set.
+
+### JWT_AUTH_COOKIE_PATH
+
+Default: `/`
+
+The path to set on the JWT cookie analogous to `SESSION_COOKIE_PATH`
+for django sessions.
+
+Has no effect unless JWT_AUTH_COOKIE is set.
+
+### JWT_AUTH_COOKIE_SECURE
+
+Default: `True`
+
+Whether to use a secure cookie for the JWT cookie analogous to
+`SESSION_COOKIE_SECURE` for django sessions.
+
+Users wishing to use JWT cookies over http (as in no TLS/SSL) need to
+set `JWT_AUTH_COOKIE_SECURE` to `False.`
+
+Has no effect unless JWT_AUTH_COOKIE is set.
+
+### JWT_AUTH_COOKIE_SAMESITE
+
+Default: `Lax`
+
+The value of the `SameSite` flag on the the JWT cookie analogous to
+`SESSION_COOKIE_SAMESITE` for django sessions.
+
+Has no effect unless JWT_AUTH_COOKIE is set.
+
+Has no effect with Django versions before 2.1.
+
 ### JWT_IMPERSONATION_COOKIE
 
 Analogous to the `JWT_AUTH_COOKIE` setting, but contains the impersonation token, i.e. the token of the user who is being impersonated.
 
 This cookie takes precedence over the `JWT_AUTH_COOKIE`. If you have both cookies and you want to end the impersonation, you have to remove the cookie. 
+
+Impersonation cookies use the `JWT_AUTH_COOKIE_*` settings.
 
 ## Extending/Overriding `JSONWebTokenAuthentication`
 

--- a/src/rest_framework_jwt/compat.py
+++ b/src/rest_framework_jwt/compat.py
@@ -2,8 +2,30 @@
 
 from __future__ import unicode_literals
 
+from datetime import datetime
+
+from django import VERSION
+
+from .settings import api_settings
 
 try:
     from django.urls import include, url
 except ImportError:
     from django.conf.urls import include, url  # noqa: F401
+
+def has_set_cookie_samesite():
+    return (VERSION >= (2,1,0))
+
+def set_cookie_with_token(response, name, token):
+    params = {
+        'expires': datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA,
+        'domain': api_settings.JWT_AUTH_COOKIE_DOMAIN,
+        'path': api_settings.JWT_AUTH_COOKIE_PATH,
+        'secure': api_settings.JWT_AUTH_COOKIE_SECURE,
+        'httponly': True
+    }
+
+    if has_set_cookie_samesite():
+        params.update({'samesite': api_settings.JWT_AUTH_COOKIE_SAMESITE})
+
+    response.set_cookie(name, token, **params)

--- a/src/rest_framework_jwt/settings.py
+++ b/src/rest_framework_jwt/settings.py
@@ -38,6 +38,10 @@ DEFAULTS = {
     'JWT_RESPONSE_PAYLOAD_HANDLER':
         'rest_framework_jwt.utils.jwt_create_response_payload',
     'JWT_AUTH_COOKIE': None,
+    'JWT_AUTH_COOKIE_DOMAIN': None,
+    'JWT_AUTH_COOKIE_PATH': '/',
+    'JWT_AUTH_COOKIE_SECURE': True,
+    'JWT_AUTH_COOKIE_SAMESITE': 'Lax',
     'JWT_IMPERSONATION_COOKIE': None,
 }
 

--- a/src/rest_framework_jwt/views.py
+++ b/src/rest_framework_jwt/views.py
@@ -2,11 +2,10 @@
 
 from __future__ import unicode_literals
 
-from datetime import datetime
-
 from rest_framework import status
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
+from .compat import set_cookie_with_token
 from .permissions import IsSuperUser
 from .authentication import JSONWebTokenAuthentication
 from .serializers import \
@@ -37,13 +36,8 @@ class BaseJSONWebTokenAPIView(GenericAPIView):
         response = Response(response_data)
 
         if api_settings.JWT_AUTH_COOKIE:
-            expiration = (
-                datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
-            )
-            response.set_cookie(
-                api_settings.JWT_AUTH_COOKIE, token, expires=expiration,
-                httponly=True
-            )
+            set_cookie_with_token(response, api_settings.JWT_AUTH_COOKIE, token)
+
         return response
 
 
@@ -103,13 +97,11 @@ class ImpersonateJSONWebTokenView(GenericAPIView):
         response = Response({"token": token})
 
         if api_settings.JWT_IMPERSONATION_COOKIE:
-            expiration = (
-                datetime.utcnow() + api_settings.JWT_EXPIRATION_DELTA
-            )
-            response.set_cookie(
-                api_settings.JWT_IMPERSONATION_COOKIE, token,
-                expires=expiration, httponly=True
-            )
+            set_cookie_with_token(
+                response,
+                api_settings.JWT_IMPERSONATION_COOKIE,
+                token)
+
         return response
 
 

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -8,8 +8,8 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import status
 
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+from rest_framework_jwt.compat import has_set_cookie_samesite
 from rest_framework_jwt.settings import api_settings
-
 
 def test_empty_credentials_returns_validation_error(call_auth_endpoint):
     expected_output = {
@@ -121,6 +121,41 @@ def test_valid_credentials_with_auth_cookie_enabled_returns_jwt_and_cookie(
 
     response = call_auth_endpoint("username", "password")
 
+    assert auth_cookie in response.cookies
+
+    setcookie = response.cookies[auth_cookie]
+
+    assert 'domain' not in setcookie.items()
+    assert setcookie['path'] == '/'
+    assert setcookie['secure'] is True
+    assert setcookie['httponly'] is True	# hardcoded
+    if has_set_cookie_samesite():
+        assert setcookie['samesite'] == 'Lax'
+
     assert response.status_code == status.HTTP_200_OK
     assert "token" in force_text(response.content)
     assert auth_cookie in response.client.cookies
+
+def test_auth_cookie_settings(
+    monkeypatch, user, call_auth_endpoint
+):
+
+    auth_cookie = "jwt-auth"
+    monkeypatch.setattr(api_settings, "JWT_AUTH_COOKIE", auth_cookie)
+    monkeypatch.setattr(api_settings, "JWT_AUTH_COOKIE_DOMAIN", '.do.main')
+    monkeypatch.setattr(api_settings, "JWT_AUTH_COOKIE_PATH", '/pa/th')
+    monkeypatch.setattr(api_settings, "JWT_AUTH_COOKIE_SECURE", False)
+    monkeypatch.setattr(api_settings, "JWT_AUTH_COOKIE_SAMESITE", 'Strict')
+
+    response = call_auth_endpoint("username", "password")
+
+    assert auth_cookie in response.cookies
+
+    setcookie = response.cookies[auth_cookie]
+
+    assert setcookie['domain'] == '.do.main'
+    assert setcookie['path'] == '/pa/th'
+    assert 'secure' not in setcookie.items()
+    assert setcookie['httponly'] is True	# hardcoded
+    if has_set_cookie_samesite():
+        assert setcookie['samesite'] == 'Strict'


### PR DESCRIPTION
We add settings analogous to `SESSION_COOKIE_*` for the JWT cookie:

    'JWT_AUTH_COOKIE_DOMAIN': None
    'JWT_AUTH_COOKIE_PATH': None
    'JWT_AUTH_COOKIE_SECURE': True
    'JWT_AUTH_COOKIE_SAMESITE': 'Lax'

with the following differences to django:

* `The HttpOnly` attribute remains hardcoded as `True` in order to avoid unintended access from client code with addition of the `Domain` attribute.

### BREAKING CHANGES with this patch:

This changes the default `Secure` attribute from `False` (actually `None` as in not present in `Set-Cookie`) to `True`. Users wishing to use JWT cookies over http (as in no TLS) need to set `JWT_AUTH_COOKIE_SECURE` to `False.`

This change is intentional to follow common best common practice.

### CHANGES:

Adds the default `Samesite` attribute `Lax`