### PR TITLE
Split try-catch of compat imports

### DIFF
--- a/changelog.d/45.bugfix.md
+++ b/changelog.d/45.bugfix.md
@@ -1,0 +1,1 @@
+Fix deprecation warnings in Django 3 caused by imports of `ugettext` and `force_text`.

--- a/src/rest_framework_jwt/compat.py
+++ b/src/rest_framework_jwt/compat.py
@@ -8,11 +8,22 @@ from django import VERSION
 
 from .settings import api_settings
 
+
 try:
-    from django.urls import include, url
+    from django.urls import include
+except ImportError:
+    from django.conf.urls import include  # noqa: F401
+
+
+try:
+  from django.conf.urls import url
+except ImportError:
+  from django.urls import url
+
+
+try:
     from django.utils.translation import gettext as gettext_lazy
 except ImportError:
-    from django.conf.urls import include, url  # noqa: F401
     from django.utils.translation import ugettext as gettext_lazy
 
 
@@ -20,7 +31,8 @@ try:
     from django.utils.encoding import smart_str
 except ImportError:
     from django.utils.encoding import smart_text as smart_str
-    
+
+
 def has_set_cookie_samesite():
     return (VERSION >= (2,1,0))
 

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -10,7 +10,6 @@ import jwt
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.utils.encoding import force_str
-from django.utils.encoding import force_text
 
 from rest_framework import serializers
 
@@ -109,7 +108,7 @@ def jwt_encode_payload(payload):
     """Encode JWT token claims."""
 
     key = api_settings.JWT_PRIVATE_KEY or jwt_get_secret_key(payload)
-    return force_text(jwt.encode(payload, key, api_settings.JWT_ALGORITHM))
+    return force_str(jwt.encode(payload, key, api_settings.JWT_ALGORITHM))
 
 
 def jwt_decode_token(token):

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import status
@@ -135,7 +135,7 @@ def test_valid_credentials_with_auth_cookie_enabled_returns_jwt_and_cookie(
         assert setcookie['samesite'] == 'Lax'
 
     assert response.status_code == status.HTTP_200_OK
-    assert "token" in force_text(response.content)
+    assert "token" in force_str(response.content)
     assert auth_cookie in response.client.cookies
 
 


### PR DESCRIPTION
In django 3 the import of url is failing, leading to the catch block
being triggered. This causes the import of the deprecated ugettext
instead of the correct gettext.