### PR TITLE
Use DRF JSON encoder for token (to allow for more data types)

### DIFF
--- a/changelog.d/50.feature.md
+++ b/changelog.d/50.feature.md
@@ -1,0 +1,1 @@
+Use DRF's JSON encoder for JWT tokens, to allow for encoding e.g. users that have UUID primary keys.

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.utils.encoding import force_str
 
 from rest_framework import serializers
+from rest_framework.utils.encoders import JSONEncoder
 
 from rest_framework_jwt.blacklist.models import BlacklistedToken
 from rest_framework_jwt.compat import gettext_lazy as _
@@ -123,7 +124,7 @@ def jwt_encode_payload(payload):
     elif isinstance(key,list):
         key = key[0]
 
-    return jwt.encode(payload, key, signing_algorithm, headers=headers).decode()
+    return jwt.encode(payload, key, signing_algorithm, headers=headers, json_encoder=JSONEncoder).decode()
 
 
 def jwt_decode_token(token):


### PR DESCRIPTION
This patch makes it possible to use user objects that have UUID primary keys.

The default Python standard library JSON encoder doesn't support anything that can't be "natively" represented in JSON, but I think it makes sense to use the [DRF `JSONEncoder`](https://github.com/encode/django-rest-framework/blob/900773ad06ed6b3e9dc67acd76c212a5b7146824/rest_framework/utils/encoders.py#L17-L21) instead, which supports e.g. sets, UUIDs, datetimes and so on in a sensible way.

