### PR TITLE
moved models import statement to after blacklist apps check

### DIFF
--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -19,7 +19,6 @@ from rest_framework_jwt.blacklist.exceptions import (
     InvalidAuthorizationHeaderPrefix,
     MissingToken,
 )
-from rest_framework_jwt.blacklist.models import BlacklistedToken
 from rest_framework_jwt.compat import gettext_lazy as _
 from rest_framework_jwt.compat import smart_str
 from rest_framework_jwt.settings import api_settings
@@ -69,6 +68,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             return None
 
         if apps.is_installed('rest_framework_jwt.blacklist'):
+            from rest_framework_jwt.blacklist.models import BlacklistedToken
             if BlacklistedToken.objects.filter(token=force_str(token)).exists():
                 msg = _('Token is blacklisted.')
                 raise exceptions.PermissionDenied(msg)

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -14,7 +14,6 @@ from django.utils.encoding import force_str
 from rest_framework import serializers
 from rest_framework.utils.encoders import JSONEncoder
 
-from rest_framework_jwt.blacklist.models import BlacklistedToken
 from rest_framework_jwt.compat import gettext_lazy as _
 from rest_framework_jwt.settings import api_settings
 
@@ -202,6 +201,7 @@ def check_payload(token):
     from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
     if apps.is_installed('rest_framework_jwt.blacklist'):
+        from rest_framework_jwt.blacklist.models import BlacklistedToken
         if BlacklistedToken.objects.filter(token=force_str(token)).exists():
             msg = _('Token is blacklisted.')
             raise serializers.ValidationError(msg)


### PR DESCRIPTION
Importing BlacklistedToken model with module imports causes RuntimeError: "Model class rest_framework_jwt.blacklist.models.BlacklistedToken doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS" when package is being used without the blacklist app.

Changing to a late import, inside the apps.is_installed('rest_framework_jwt.blacklist') resolves this error.