### PR TITLE
OAuth2 header request is not working.

### DIFF
--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -66,6 +66,8 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             token = self.get_token_from_request(request)
         except MissingToken:
             return None
+        except InvalidAuthorizationHeaderPrefix:
+            return None
 
         if apps.is_installed('rest_framework_jwt.blacklist'):
             from rest_framework_jwt.blacklist.models import BlacklistedToken
@@ -92,8 +94,6 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
         try:
             return cls.get_token_from_authorization_header(authorization_header)
-        except InvalidAuthorizationHeaderPrefix as error:
-            raise exceptions.AuthenticationFailed(error.msg)
         except InvalidAuthorizationCredentials:
             return cls.get_token_from_cookies(request.COOKIES)
 


### PR DESCRIPTION
When the Authorization header is sent with a prefix other than the configured one drf-jwt raises an AuthenticationFailed. 
This means that authentication is completely stopped and other auth plugins don't get a chance to run.

Two issues reported.
https://github.com/Styria-Digital/django-rest-framework-jwt/issues/63
https://github.com/Styria-Digital/django-rest-framework-jwt/issues/57

When the Authorization header is sent with a prefix
other JWT it trigger error.