### PR TITLE
In case of different auth header it triggers error instead of None

### DIFF
--- a/changelog.d/65.doc.md
+++ b/changelog.d/65.doc.md
@@ -1,0 +1,2 @@
+When the Authorization header is sent with a different prefix other than default it raises error. 
+It should return None and continue toward the other authentication middleware.

--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -16,7 +16,6 @@ from rest_framework.authentication import (
 
 from rest_framework_jwt.blacklist.exceptions import (
     InvalidAuthorizationCredentials,
-    InvalidAuthorizationHeaderPrefix,
     MissingToken,
 )
 from rest_framework_jwt.compat import gettext_lazy as _
@@ -64,6 +63,8 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         """
         try:
             token = self.get_token_from_request(request)
+            if token is None:
+                return None
         except MissingToken:
             return None
 
@@ -92,8 +93,6 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
         try:
             return cls.get_token_from_authorization_header(authorization_header)
-        except InvalidAuthorizationHeaderPrefix as error:
-            raise exceptions.AuthenticationFailed(error.msg)
         except InvalidAuthorizationCredentials:
             return cls.get_token_from_cookies(request.COOKIES)
 
@@ -105,7 +104,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             raise InvalidAuthorizationCredentials
         else:
             if not cls.prefixes_match(prefix):
-                raise InvalidAuthorizationHeaderPrefix
+                return None
             if not token:
                 raise InvalidAuthorizationCredentials
             return token

--- a/src/rest_framework_jwt/blacklist/exceptions.py
+++ b/src/rest_framework_jwt/blacklist/exceptions.py
@@ -16,8 +16,3 @@ class InvalidAuthorizationCredentials(AuthenticationFailed):
     msg = _('Invalid Authorization header.')
     default_code = 'invalid_authorization_credentials'
 
-
-class InvalidAuthorizationHeaderPrefix(AuthenticationFailed):
-    status_code = 401
-    msg = _('Authentication credentials were not provided.')
-    default_code = 'invalid_authorization_header_prefix'

--- a/tests/views/test_integration.py
+++ b/tests/views/test_integration.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import base64
 import pytest
 
 from rest_framework import status
@@ -180,3 +181,19 @@ def test_view__auth_cookie(monkeypatch, user, call_auth_endpoint):
     response = response.client.get(url)
 
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_view_returns_200_with_basic_authentication(api_client, user):
+    credentials = "Basic " + base64.b64encode('username:password'.encode('utf-8')).decode('utf-8')
+    api_client.credentials(HTTP_AUTHORIZATION=credentials)
+    url = reverse("test-view")
+    response = api_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_view_returns_401_with_invalid_basic_authentication(api_client, user):
+    credentials = "Basic " + base64.b64encode('username:pass'.encode('utf-8')).decode('utf-8')
+    api_client.credentials(HTTP_AUTHORIZATION=credentials)
+    url = reverse("test-view")
+    response = api_client.get(url)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
When the Authorization header is sent with a different prefix other than default it raises error.
It should return None so that other auth class can validate it. This issue is appearing due to this [change](https://github.com/Styria-Digital/django-rest-framework-jwt/pull/27/files#diff-bc0105dbb10d8b2bcacf8d191d5d0195R105).

Two issues already reported 
https://github.com/Styria-Digital/django-rest-framework-jwt/issues/57
https://github.com/Styria-Digital/django-rest-framework-jwt/issues/63