### PR TITLE
Add JSON web token ID claim

### DIFF
--- a/changelog.d/69.feature.md
+++ b/changelog.d/69.feature.md
@@ -1,2 +1,2 @@
-Include a token ID claim (`jti`) in all tokens.
-For tokens resulting from refresh, include the token ID of the original token in the chain of refreshes as `orig_jti`.
+Default to including a token ID claim (`jti`) in all tokens.
+For tokens resulting from refresh, also include the token ID of the original token in the chain of refreshes as `orig_jti`.

--- a/changelog.d/69.feature.md
+++ b/changelog.d/69.feature.md
@@ -1,2 +1,2 @@
 Include a token ID claim (`jti`) in all tokens.
-For refreshable tokens, include the token ID of the original token in the chain of refreshes as `orig_jti`.
+For tokens resulting from refresh, include the token ID of the original token in the chain of refreshes as `orig_jti`.

--- a/changelog.d/69.feature.md
+++ b/changelog.d/69.feature.md
@@ -1,0 +1,2 @@
+Include a token ID claim (`jti`) in all tokens.
+For refreshable tokens, include the token ID of the original token in the chain of refreshes as `orig_jti`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,6 +339,14 @@ have a `kid` header with a defined key.
 
 Default is `False`.
 
+### JWT_REQUIRE_TOKEN_ID
+
+Expect all tokens to have a `jti` token id claim, and refreshable tokens to have an `orig_jti` claim.
+
+These claims have been added automatically since version ???. Once all valid tokens in your environment have these claims, we recommend setting this to `True`.
+
+Default is `False`.
+
 ### JWT_AUDIENCE
 
 This is a string that will be checked against the `aud` field of the token, if present.

--- a/docs/index.md
+++ b/docs/index.md
@@ -343,7 +343,11 @@ Default is `False`.
 
 Expect all tokens to have a `jti` token id claim, and refreshable tokens to have an `orig_jti` claim.
 
-These claims have been added automatically since version ???. Once all valid tokens in your environment have these claims, we recommend setting this to `True`.
+These claims have been included automatically since version 1.17.
+
+For new installations, please override the default and set this to `True`, as all tokens will have the claims from the outset.
+
+For existing installations, we recommend setting this to `True` once all of the valid tokens in your production environment were produced by version 1.17 or later. This will usually be after `JWT_EXPIRATION_DELTA` has elapsed from upgrading to version 1.17 or higher.
 
 Default is `False`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -341,11 +341,11 @@ Default is `False`.
 
 ### JWT_REQUIRE_TOKEN_ID
 
-Expect all tokens to have a `jti` token id claim, and refreshable tokens to have an `orig_jti` claim.
+Expect all tokens to have a `jti` token id claim.
 
-These claims have been included automatically since version 1.17.
+This claim has been included automatically since version 1.17.
 
-For new installations, please override the default and set this to `True`, as all tokens will have the claims from the outset.
+For new installations, please override the default and set this to `True`, as every token will have an id from the outset.
 
 For existing installations, we recommend setting this to `True` once all of the valid tokens in your production environment were produced by version 1.17 or later. This will usually be after `JWT_EXPIRATION_DELTA` has elapsed from upgrading to version 1.17 or higher.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,8 @@ JWT_AUTH = {
     'JWT_PRIVATE_KEY': None,
     'JWT_PUBLIC_KEY': None,
     'JWT_ALGORITHM': 'HS256',
+    'JWT_INSIST_ON_KID': False,
+    'JWT_TOKEN_ID': 'include',
     'JWT_AUDIENCE': None,
     'JWT_ISSUER': None,
     'JWT_ENCODE_HANDLER':

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,17 +339,23 @@ have a `kid` header with a defined key.
 
 Default is `False`.
 
-### JWT_REQUIRE_TOKEN_ID
+### JWT_TOKEN_ID
 
-Expect all tokens to have a `jti` token id claim.
+Configure whether tokens have a `jti` token id claim (and refreshed tokens have a `orig_jti` claim).
 
-This claim has been included automatically since version 1.17.
+May be set to:
 
-For new installations, please override the default and set this to `True`, as every token will have an id from the outset.
+* `off`: do not include token id claims in tokens
+* `include`: add token id claims to tokens, but continue accepting old tokens without them
+* `require`: add token id claims to tokens, and reject tokens that lack them
 
-For existing installations, we recommend setting this to `True` once all of the valid tokens in your production environment were produced by version 1.17 or later. This will usually be after `JWT_EXPIRATION_DELTA` has elapsed from upgrading to version 1.17 or higher.
+The default has been to include these claims since version 1.17, so when upgrading
 
-Default is `False`.
+For new installations, please override the default and set this to `require`, as every token will have an id from the outset.
+
+For existing installations, when migrating from an older version (pre-1.17) or when changing the setting from `off`, we recommend setting this to `require` once all of the valid tokens have the id claims. This will typically be after `JWT_EXPIRATION_DELTA` has elapsed since upgrading or allowing id claims to be included.
+
+Default is `include`.
 
 ### JWT_AUDIENCE
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -351,7 +351,7 @@ May be set to:
 * `include`: add token id claims to tokens, but continue accepting old tokens without them
 * `require`: add token id claims to tokens, and reject tokens that lack them
 
-The default has been to include these claims since version 1.17, so when upgrading
+The default has been to include these claims since version 1.17.
 
 For new installations, please override the default and set this to `require`, as every token will have an id from the outset.
 

--- a/src/rest_framework_jwt/serializers.py
+++ b/src/rest_framework_jwt/serializers.py
@@ -117,11 +117,11 @@ class RefreshAuthTokenSerializer(serializers.Serializer):
         new_payload['orig_iat'] = orig_iat
 
         # Track the token ID of the original token, if it exists
-        orig_jti = payload.get('orig_jti')
+        orig_jti = payload.get('orig_jti') or payload.get('jti')
         if orig_jti:
             new_payload['orig_jti'] = orig_jti
         elif api_settings.JWT_REQUIRE_TOKEN_ID:
-            msg = _('orig_jti field not found in token.')
+            msg = _('orig_jti or jti field not found in token.')
             raise serializers.ValidationError(msg)
 
         return {

--- a/src/rest_framework_jwt/serializers.py
+++ b/src/rest_framework_jwt/serializers.py
@@ -120,6 +120,9 @@ class RefreshAuthTokenSerializer(serializers.Serializer):
         orig_jti = payload.get('orig_jti')
         if orig_jti:
             new_payload['orig_jti'] = orig_jti
+        elif api_settings.JWT_REQUIRE_TOKEN_ID:
+            msg = _('orig_jti field not found in token.')
+            raise serializers.ValidationError(msg)
 
         return {
             'token':

--- a/src/rest_framework_jwt/serializers.py
+++ b/src/rest_framework_jwt/serializers.py
@@ -120,7 +120,7 @@ class RefreshAuthTokenSerializer(serializers.Serializer):
         orig_jti = payload.get('orig_jti') or payload.get('jti')
         if orig_jti:
             new_payload['orig_jti'] = orig_jti
-        elif api_settings.JWT_REQUIRE_TOKEN_ID:
+        elif api_settings.JWT_TOKEN_ID == 'require':
             msg = _('orig_jti or jti field not found in token.')
             raise serializers.ValidationError(msg)
 

--- a/src/rest_framework_jwt/serializers.py
+++ b/src/rest_framework_jwt/serializers.py
@@ -116,6 +116,11 @@ class RefreshAuthTokenSerializer(serializers.Serializer):
         new_payload = JSONWebTokenAuthentication.jwt_create_payload(user)
         new_payload['orig_iat'] = orig_iat
 
+        # Track the token ID of the original token, if it exists
+        orig_jti = payload.get('orig_jti')
+        if orig_jti:
+            new_payload['orig_jti'] = orig_jti
+
         return {
             'token':
                 JSONWebTokenAuthentication.jwt_encode_payload(new_payload),

--- a/src/rest_framework_jwt/settings.py
+++ b/src/rest_framework_jwt/settings.py
@@ -17,7 +17,7 @@ DEFAULTS = {
     'JWT_PUBLIC_KEY': None,
     'JWT_ALGORITHM': 'HS256',
     'JWT_INSIST_ON_KID': False,
-    'JWT_REQUIRE_TOKEN_ID': False,
+    'JWT_TOKEN_ID': 'include',
     'JWT_AUDIENCE': None,
     'JWT_ISSUER': None,
     'JWT_ENCODE_HANDLER':
@@ -72,3 +72,8 @@ if not isinstance(
     raise ImproperlyConfigured(
         '`JWT_REFRESH_EXPIRATION_DELTA` setting must be instance of '
         '`datetime.timedelta`')
+
+if api_settings.JWT_TOKEN_ID not in {'off', 'include', 'require'}:
+    raise ImproperlyConfigured(
+        "`JWT_TOKEN_ID` setting must be 'off', 'include' or 'require'"
+    )

--- a/src/rest_framework_jwt/settings.py
+++ b/src/rest_framework_jwt/settings.py
@@ -17,6 +17,7 @@ DEFAULTS = {
     'JWT_PUBLIC_KEY': None,
     'JWT_ALGORITHM': 'HS256',
     'JWT_INSIST_ON_KID': False,
+    'JWT_REQUIRE_TOKEN_ID': False,
     'JWT_AUDIENCE': None,
     'JWT_ISSUER': None,
     'JWT_ENCODE_HANDLER':

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -69,11 +69,13 @@ def jwt_create_payload(user):
     expiration_time = issued_at_time + api_settings.JWT_EXPIRATION_DELTA
 
     payload = {
-        'jti': uuid.uuid4(),
         'username': user.get_username(),
         'iat': unix_epoch(issued_at_time),
         'exp': expiration_time
     }
+
+    if api_settings.JWT_TOKEN_ID != 'off':
+        payload['jti'] = uuid.uuid4()
 
     if api_settings.JWT_PAYLOAD_INCLUDE_USER_ID:
         payload['user_id'] = user.pk
@@ -230,7 +232,7 @@ def check_user(payload):
         msg = _('Invalid token.')
         raise serializers.ValidationError(msg)
 
-    if api_settings.JWT_REQUIRE_TOKEN_ID and not payload.get('jti'):
+    if api_settings.JWT_TOKEN_ID == 'require' and not payload.get('jti'):
         msg = _('Invalid token.')
         raise serializers.ValidationError(msg)
 

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -6,6 +6,7 @@ from calendar import timegm
 from datetime import datetime
 
 import jwt
+import uuid
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -68,6 +69,7 @@ def jwt_create_payload(user):
     expiration_time = issued_at_time + api_settings.JWT_EXPIRATION_DELTA
 
     payload = {
+        'jti': uuid.uuid4(),
         'username': user.get_username(),
         'iat': unix_epoch(issued_at_time),
         'exp': expiration_time

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -234,6 +234,10 @@ def check_user(payload):
         msg = _('Invalid token.')
         raise serializers.ValidationError(msg)
 
+    if api_settings.JWT_REQUIRE_TOKEN_ID and not payload.get('jti'):
+        msg = _('Invalid token.')
+        raise serializers.ValidationError(msg)
+
     # Make sure user exists
     try:
         User = get_user_model()

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -89,6 +89,10 @@ def jwt_create_payload(user):
     if api_settings.JWT_ALLOW_REFRESH:
         payload['orig_iat'] = unix_epoch(issued_at_time)
 
+        # Include the original token ID so we can associate
+        # fresh tokens with the original
+        payload['orig_jti'] = payload['jti']
+
     if api_settings.JWT_AUDIENCE is not None:
         payload['aud'] = api_settings.JWT_AUDIENCE
 

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -89,10 +89,6 @@ def jwt_create_payload(user):
     if api_settings.JWT_ALLOW_REFRESH:
         payload['orig_iat'] = unix_epoch(issued_at_time)
 
-        # Include the original token ID so we can associate
-        # fresh tokens with the original
-        payload['orig_jti'] = payload['jti']
-
     if api_settings.JWT_AUDIENCE is not None:
         payload['aud'] = api_settings.JWT_AUDIENCE
 

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -105,6 +105,7 @@ def test_valid_credentials_return_jwt_with_expected_claims(user, call_auth_endpo
         'exp',
         'user_id',
         'orig_iat',
+        'orig_jti',
     }
     assert payload.keys() == expected_claims
 

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -90,7 +90,6 @@ def test_valid_credentials_return_jwt_uuid4_token_id(user, call_auth_endpoint):
 
     pattern = r'[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\Z'
     assert re.match(pattern, payload['jti'])
-    assert payload['jti'] == payload['orig_jti']
 
 
 def test_valid_credentials_return_jwt_with_expected_claims(user, call_auth_endpoint):
@@ -106,7 +105,6 @@ def test_valid_credentials_return_jwt_with_expected_claims(user, call_auth_endpo
         'exp',
         'user_id',
         'orig_iat',
-        'orig_jti',
     }
     assert payload.keys() == expected_claims
 

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -92,6 +92,16 @@ def test_valid_credentials_return_jwt_uuid4_token_id(user, call_auth_endpoint):
     assert re.match(pattern, payload['jti'])
 
 
+def test_valid_credentials_return_jwt_without_token_id_when_configured_off(monkeypatch, user, call_auth_endpoint):
+    monkeypatch.setattr(api_settings, "JWT_TOKEN_ID", "off")
+    response = call_auth_endpoint("username", "password")
+
+    token = response.json()["token"]
+    payload = JSONWebTokenAuthentication.jwt_decode_token(token)
+
+    assert "jti" not in payload
+
+
 def test_valid_credentials_return_jwt_with_expected_claims(user, call_auth_endpoint):
     response = call_auth_endpoint("username", "password")
 

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -90,6 +90,7 @@ def test_valid_credentials_return_jwt_uuid4_token_id(user, call_auth_endpoint):
 
     pattern = r'[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\Z'
     assert re.match(pattern, payload['jti'])
+    assert payload['jti'] == payload['orig_jti']
 
 
 def test_valid_credentials_return_jwt_with_expected_claims(user, call_auth_endpoint):

--- a/tests/views/test_refresh.py
+++ b/tests/views/test_refresh.py
@@ -76,6 +76,26 @@ def test_valid_token__returns_new_token(call_auth_refresh_endpoint, user):
     assert refresh_token != auth_token
 
 
+def test_valid_token__returns_new_token_preserving_original_token_id(call_auth_refresh_endpoint, user):
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+
+    refresh_response = call_auth_refresh_endpoint(auth_token)
+    refresh_token = refresh_response.json()["token"]
+    refresh_token_payload = JSONWebTokenAuthentication.jwt_decode_token(refresh_token)
+    assert refresh_token_payload["orig_jti"] == str(payload["orig_jti"])
+
+
+def test_valid_token__returns_new_token_with_new_token_id(call_auth_refresh_endpoint, user):
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+
+    refresh_response = call_auth_refresh_endpoint(auth_token)
+    refresh_token = refresh_response.json()["token"]
+    refresh_token_payload = JSONWebTokenAuthentication.jwt_decode_token(refresh_token)
+    assert refresh_token_payload["jti"] != str(payload["jti"])
+
+
 def test_expired_token__returns_validation_error(
     call_auth_refresh_endpoint, user
 ):

--- a/tests/views/test_refresh.py
+++ b/tests/views/test_refresh.py
@@ -53,6 +53,24 @@ def test_without_orig_iat_in_payload__returns_validation_error(
     assert response.json() == expected_output
 
 
+def test_require_id_without_orig_jti_in_payload__returns_validation_error(
+    monkeypatch, call_auth_refresh_endpoint, user
+):
+    monkeypatch.setattr(api_settings, "JWT_REQUIRE_TOKEN_ID", True)
+
+    # create token without orig_jti in payload
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    del payload["orig_jti"]
+    auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+
+    expected_output = {
+        "non_field_errors": [_("orig_jti field not found in token.")]
+    }
+
+    response = call_auth_refresh_endpoint(auth_token)
+    assert response.json() == expected_output
+
+
 def test_refresh_limit_expired__returns_validation_error(
     call_auth_refresh_endpoint, user
 ):

--- a/tests/views/test_refresh.py
+++ b/tests/views/test_refresh.py
@@ -11,6 +11,7 @@ from rest_framework_jwt.blacklist.models import BlacklistedToken
 from rest_framework_jwt.compat import gettext_lazy as _
 from rest_framework_jwt.settings import api_settings
 
+import uuid
 
 def test_invalid_token__returns_validation_error(call_auth_refresh_endpoint):
     expected_output = {"non_field_errors": [_("Error decoding token.")]}
@@ -53,22 +54,6 @@ def test_without_orig_iat_in_payload__returns_validation_error(
     assert response.json() == expected_output
 
 
-def test_require_id_without_orig_jti_in_payload__returns_validation_error(
-    monkeypatch, call_auth_refresh_endpoint, user
-):
-    monkeypatch.setattr(api_settings, "JWT_REQUIRE_TOKEN_ID", True)
-
-    # create token without orig_jti in payload
-    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
-    del payload["orig_jti"]
-    auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
-
-    expected_output = {
-        "non_field_errors": [_("orig_jti field not found in token.")]
-    }
-
-    response = call_auth_refresh_endpoint(auth_token)
-    assert response.json() == expected_output
 
 
 def test_refresh_limit_expired__returns_validation_error(
@@ -94,8 +79,20 @@ def test_valid_token__returns_new_token(call_auth_refresh_endpoint, user):
     assert refresh_token != auth_token
 
 
-def test_valid_token__returns_new_token_preserving_original_token_id(call_auth_refresh_endpoint, user):
+def test_valid_token__returns_new_token_preserving_token_id_for_first_refresh(call_auth_refresh_endpoint, user):
     payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+    assert "orig_jti" not in payload
+
+    refresh_response = call_auth_refresh_endpoint(auth_token)
+    refresh_token = refresh_response.json()["token"]
+    refresh_token_payload = JSONWebTokenAuthentication.jwt_decode_token(refresh_token)
+    assert refresh_token_payload["orig_jti"] == str(payload["jti"])
+
+
+def test_valid_token__returns_new_token_preserving_original_token_id_for_subsequent_refreshes(call_auth_refresh_endpoint, user):
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    payload["orig_jti"] = uuid.uuid4()
     auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
 
     refresh_response = call_auth_refresh_endpoint(auth_token)

--- a/tests/views/test_verification.py
+++ b/tests/views/test_verification.py
@@ -44,7 +44,7 @@ def test_token_without_username_returns_validation_error(
 def test_token_without_required_token_id_returns_validation_error(
     monkeypatch, user, call_auth_verify_endpoint
 ):
-    monkeypatch.setattr(api_settings, "JWT_REQUIRE_TOKEN_ID", True)
+    monkeypatch.setattr(api_settings, "JWT_TOKEN_ID", "require")
     payload = JSONWebTokenAuthentication.jwt_create_payload(user)
     payload.pop("jti")
     auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)

--- a/tests/views/test_verification.py
+++ b/tests/views/test_verification.py
@@ -41,6 +41,21 @@ def test_token_without_username_returns_validation_error(
     assert verify_response.json() == expected_output
 
 
+def test_token_without_required_token_id_returns_validation_error(
+    monkeypatch, user, call_auth_verify_endpoint
+):
+    monkeypatch.setattr(api_settings, "JWT_REQUIRE_TOKEN_ID", True)
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    payload.pop("jti")
+    auth_token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+
+    expected_output = {"non_field_errors": [_("Invalid token.")]}
+
+    verify_response = call_auth_verify_endpoint(auth_token)
+
+    assert verify_response.json() == expected_output
+
+
 def test_token_with_invalid_username_returns_validation_error(
     user, call_auth_verify_endpoint
 ):


### PR DESCRIPTION
* Add a JWT ID to the payload. (6243308)

    This is a fairly common optional claim.
    
    I have a case where I want to track audit records back to the associated authentication event, so being able to identify the token reasonably uniquely would be very helpful.

* Track the original token ID when refreshing tokens. (8b42c57)

    This allows us to tie any authorized request back to the original authentication event, identified by the original token's ID.
    
    It should also be useful for allowing a stronger blacklist check not just for the token but for any token stemming from the same original token.

* Add check that a new token sets both the token id and original token id to the same value. (2e67fd2)


* Add config option to enforce that tokens should have a token id for verification (and original id for refresh). (a3721e5)

    I think it's preferable to reject these, but for someone upgrading a running service it would be unsafe to start insisting that all tokens have token ids immediately. Having a setting allows the operator to start enforcing it after all of their valid tokens were made by a new enough version of the library, which depends on how they have configured expiration times.
    
    (I need to update the docs once I know which version the jti change will ship in.)


---

I considered doing this with a custom payload handler, but it's not really possible to get the link back to the original token ID that way, so I can add an identifier, but I can't see a good way to preserve the relationship to the original token.

I'm hoping it's reasonable to always add this, rather than making it configurable, but please let me know if you'd like it to be optional. We could also allow someone to configure their own function for creating an identifier, but I chose to make it a random UUID4 for starters, which I believe satisfies the spec's requirement for a "negligible probability" of colliding identifiers.

I'd like to build on this later by strengthening the 'blacklist' check to disallow the whole (potentially branching) chain of tokens, rather than just the current token at the time the user invalidates their token. But I think this is still useful to ship independently.

I have two use cases this will help me solve:

- associate any authenticated request with the original login event, to enable more thorough investigation of activity associated with a suspicious login 
- allow identifying a blacklisted token outside of the django service without needing to share the entire token

(I'll add release notes if the basic approach here seems acceptable.)