### PR TITLE
get_token_from_request: Catch UnicodeDecodeError

### DIFF
--- a/changelog.d/71.feature.md
+++ b/changelog.d/71.feature.md
@@ -1,0 +1,2 @@
+If the authentication header cant be parsed, fall back to
+cookies or allow other handlers.

--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -92,11 +92,11 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
     @classmethod
     def get_token_from_request(cls, request):
-        authorization_header = force_str(get_authorization_header(request))
-
         try:
+            authorization_header = force_str(get_authorization_header(request))
+
             return cls.get_token_from_authorization_header(authorization_header)
-        except InvalidAuthorizationCredentials:
+        except (InvalidAuthorizationCredentials, UnicodeDecodeError):
             return cls.get_token_from_cookies(request.COOKIES)
 
     @classmethod


### PR DESCRIPTION
If the authentication header cant be parsed, fall back to
cookies or allow other handlers.

Closes https://github.com/Styria-Digital/django-rest-framework-jwt/issues/70