### PR TITLE
Handle more invalid token errors for authenticated calls

### DIFF
--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -82,6 +82,9 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except jwt.DecodeError:
             msg = _('Error decoding token.')
             raise exceptions.AuthenticationFailed(msg)
+        except jwt.InvalidTokenError:
+            msg = _('Invalid token.')
+            raise exceptions.AuthenticationFailed(msg)
 
         user = self.authenticate_credentials(payload)
 

--- a/tests/views/test_integration.py
+++ b/tests/views/test_integration.py
@@ -66,6 +66,52 @@ def test_view_returns_401_for_expired_token(api_client, user):
     assert response.json() == expected_output
 
 
+def test_view_returns_401_for_missing_required_key_id(monkeypatch, api_client, user):
+    monkeypatch.setattr(api_settings, "JWT_INSIST_ON_KID", True)
+    header = '{"alg": "HS256", "typ": "JWT"}'
+    token = base64.b64encode(header.encode('ascii')) + "..".encode('ascii')
+
+    api_client.credentials(HTTP_AUTHORIZATION="Bearer " + token.decode())
+
+    expected_output = {"detail": _("Error decoding token.")}
+
+    url = reverse("test-view")
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == expected_output
+
+
+def test_view_returns_401_for_unknown_required_key_id(monkeypatch, api_client, user):
+    monkeypatch.setattr(api_settings, "JWT_INSIST_ON_KID", True)
+    header = '{"alg": "HS256", "kid": "unknown-key-id", "typ": "JWT"}'
+    token = base64.b64encode(header.encode('ascii')) + "..".encode('ascii')
+
+    api_client.credentials(HTTP_AUTHORIZATION="Bearer " + token.decode())
+
+    expected_output = {"detail": _("Error decoding token.")}
+
+    url = reverse("test-view")
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == expected_output
+
+
+def test_view_returns_401_for_corrupt_signature(api_client, user):
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    token = JSONWebTokenAuthentication.jwt_encode_payload(payload) + "x"
+    api_client.credentials(HTTP_AUTHORIZATION="Bearer " + token)
+
+    expected_output = {"detail": _("Error decoding token.")}
+
+    url = reverse("test-view")
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == expected_output
+
+
 def test_view_returns_401_to_deactivated_user(api_client, user):
     payload = JSONWebTokenAuthentication.jwt_create_payload(user)
     token = JSONWebTokenAuthentication.jwt_encode_payload(payload)


### PR DESCRIPTION
* Add some more tests for error cases with 'bad' tokens. (c2c2c8b)


* Handle more token errors. (a33765d)

    There are a number of subclasses of InvalidTokenError that bubble up as unhandled errors in the old code.
    
    I've kept the explicit handling of DecodeError and Expired Signature, which are also children of InvalidTokenError, in order to preserve their distinctive responses.

(There's a similar ladder in rest_framework_jwt.utils::check_payload, but I didn't dig very far into whether that should also be handling all InvalidTokenErrors.)

I ran into this after migrating algorithms, and after dropping support for the old algorithm I get a 500 error from the unhandled `InvalidAlgorithmError` when using an 'old' token. Digging in, I saw there were a handful of other cases that would also bubble up as unhandled errors.

I didn't try and handle `PyJWTError` or `InvalidKeyError` (which are higher up the tree of exceptions than `InvalidTokenError`) as those seem more like things that are misconfigured, whereas I think everything under `InvalidTokenError` could reasonably be some oddball on the internet sending a funny-looking token.