### PR TITLE
Handle more token errors for check_payload

### DIFF
--- a/changelog.d/77.bugfix.md
+++ b/changelog.d/77.bugfix.md
@@ -1,0 +1,1 @@
+Improve error handling for invalid tokens.

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -218,6 +218,9 @@ def check_payload(token):
     except jwt.DecodeError:
         msg = _('Error decoding token.')
         raise serializers.ValidationError(msg)
+    except jwt.InvalidTokenError:
+        msg = _('Invalid token.')
+        raise serializers.ValidationError(msg)
 
     return payload
 

--- a/tests/views/test_refresh.py
+++ b/tests/views/test_refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import base64
 from datetime import timedelta
 
 from django.utils import timezone
@@ -139,4 +140,17 @@ def test_blacklisted_token__returns_validation_error(
     expected_output = {"non_field_errors": [_("Token is blacklisted.")]}
 
     refresh_response = call_auth_refresh_endpoint(auth_token)
+    assert refresh_response.json() == expected_output
+
+
+def test_refresh_with_invalid_algorithm__returns_validation_error(
+    call_auth_refresh_endpoint, user
+):
+    header = '{"alg": "bad", "typ": "JWT"}'
+    token_bytes = base64.b64encode(header.encode('ascii')) + "..".encode('ascii')
+    token = token_bytes.decode()
+
+    expected_output = {"non_field_errors": [_("Invalid token.")]}
+
+    refresh_response = call_auth_refresh_endpoint(token)
     assert refresh_response.json() == expected_output


### PR DESCRIPTION
There are various subclasses of InvalidTokenError that end up bubbling up as unhandled errors in the old code, including InvalidAlgorithmError.

This is very similar to the fix in #72, but for the check_payload version of the similar logic.

Again, I've kept the explicit handling of DecodeError and Expired Signature, which are also children of InvalidTokenError, so that we don't change the behaviour for previously handled errors.

I think it would be good to unify the logic for these at some point, but for now I'm just handling the same errors in both places.