### PR TITLE
Avoid unhandled error for tokens with an unrecognized key id

### DIFF
--- a/changelog.d/78.bugfix.md
+++ b/changelog.d/78.bugfix.md
@@ -1,0 +1,1 @@
+Improve error handling for tokens with an unrecognized key identifier (`kid`).

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -163,9 +163,9 @@ def jwt_decode_token(token):
             try:
                 keys = keys[kid]
             except KeyError:
-                raise jwt.exceptions.InvalidKeyError
+                raise jwt.exceptions.InvalidTokenError
         elif api_settings.JWT_INSIST_ON_KID:
-            raise jwt.exceptions.InvalidKeyError
+            raise jwt.exceptions.InvalidTokenError
         else:
             keys = list(keys.values())
 

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -10,7 +10,7 @@ from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy as _
 
 from jwt import get_unverified_header
-from jwt.exceptions import InvalidKeyError, InvalidAlgorithmError, InvalidSignatureError
+from jwt.exceptions import InvalidAlgorithmError, InvalidSignatureError, InvalidTokenError
 
 from pytest import skip, fixture, raises
 
@@ -352,7 +352,7 @@ def test_keys_key_id_not_found(
     secret_key = OrderedDict(hash3="three")
     monkeypatch.setattr(api_settings, "JWT_SECRET_KEY", secret_key)
 
-    with raises(InvalidKeyError):
+    with raises(InvalidTokenError):
         assert JSONWebTokenAuthentication.jwt_decode_token(token) == None
 
 def test_insist_on_key_id(
@@ -377,7 +377,7 @@ def test_insist_on_key_id(
 
     # check if we insist on the key beging named
     monkeypatch.setattr(api_settings, "JWT_INSIST_ON_KID", True)
-    with raises(InvalidKeyError):
+    with raises(InvalidTokenError):
         assert JSONWebTokenAuthentication.jwt_decode_token(token) == None
 
 def test_InvalidAlgorithmError():


### PR DESCRIPTION
Raise an invalid token error when the incoming token has an unrecognized key id.

Key error isn't obviously incorrect, but looking at how it's used in the jwt package, it looks to generally be used for malformed keys, which I would expect to be a sign something was misconfigured, rather than a bad value from a client.

By switching this to InvalidTokenError, we'll properly handle the error when authenticating. At present, we handle InvalidTokenError and some specific subclasses, but InvalidKeyError bubbles up as an unhandled error leading to a 500 error from Django. (InvalidTokenError and InvalidKeyError are siblings in the exception hierarchy, under PyJWTError.)

(I tried this locally, hitting an authenticated endpoint using a token with an unrecognized key id. Without this change, I get a 500 error for the unhandled InvalidKeyError and with it I get the expected Invalid token / authentication_failed JSON response.)