### PR TITLE
Fix broken test in Python 2.7 on master

### DIFF
--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -116,7 +116,7 @@ def test_valid_credentials_return_jwt_with_expected_claims(user, call_auth_endpo
         'user_id',
         'orig_iat',
     }
-    assert payload.keys() == expected_claims
+    assert set(payload.keys()) == expected_claims
 
 
 def test_valid_credentials_with_aud_and_iss_settings_return_jwt(


### PR DESCRIPTION
Use a set for the comparison.

This shouldn't make a difference for current versions of Python, but in 2.7 this test is currently failing because it is comparing the list from .keys() to a set.

(I only noticed the broken test when I saw the broken test in the build for #78.)