### PR TITLE
Make README.md render correctly on PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = drf-jwt
 version = attr: rest_framework_jwt.__version__
 description = JSON Web Token based authentication for Django REST framework
 long_description = file: README.md
+long_description_content_type = 'text/markdown'
 keywords = Styria CMS, JSON API
 author = Styria Digital
 author_email = digital-development@styria.hr


### PR DESCRIPTION
Add content type of README.md to setup.cfg so that it renders on PyPI.