### PR TITLE
Add PyJWT 2.x support

### DIFF
--- a/changelog.d/91.feature.md
+++ b/changelog.d/91.feature.md
@@ -1,0 +1,1 @@
+Adds PyJWT 2.x support. Note that this is only supported on Python 3.6+ as PyJWT 2.x only supports that. PyJWT 1.x is also still supported and continues to work on the same set of Python versions as before.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*
 zip_safe = False
 include_package_data = True
 install_requires =
-    PyJWT[crypto]>=1.5.2,<2.0.0
+    PyJWT[crypto]>=1.5.2,<3.0.0
     Django>=1.11
     djangorestframework>=3.7
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ test =
     pytest-cov
     pytest-django
     pytest-runner
-    cryptography==2.0.3
     six
 docs =
     mkdocs==0.13.2

--- a/src/rest_framework_jwt/authentication.py
+++ b/src/rest_framework_jwt/authentication.py
@@ -20,6 +20,7 @@ from rest_framework_jwt.blacklist.exceptions import (
 )
 from rest_framework_jwt.compat import gettext_lazy as _
 from rest_framework_jwt.compat import smart_str
+from rest_framework_jwt.compat import ExpiredSignature
 from rest_framework_jwt.settings import api_settings
 
 
@@ -70,7 +71,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
 
         try:
             payload = self.jwt_decode_token(token)
-        except jwt.ExpiredSignature:
+        except ExpiredSignature:
             msg = _('Token has expired.')
             raise exceptions.AuthenticationFailed(msg)
         except jwt.DecodeError:

--- a/src/rest_framework_jwt/blacklist/permissions.py
+++ b/src/rest_framework_jwt/blacklist/permissions.py
@@ -1,11 +1,8 @@
-import jwt
-
 from rest_framework.permissions import BasePermission
 
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from rest_framework_jwt.blacklist.models import BlacklistedToken
-from rest_framework_jwt.compat import gettext_lazy as _
-
+from rest_framework_jwt.compat import gettext_lazy as _, jwt_decode
 
 class IsNotBlacklisted(BasePermission):
     message = _('You have been blacklisted.')
@@ -18,5 +15,5 @@ class IsNotBlacklisted(BasePermission):
             return True
 
         # The token should already be validated before we call this.
-        payload = jwt.decode(token, None, False)
+        payload = jwt_decode(token, None, verify=False)
         return not BlacklistedToken.is_blocked(token, payload)

--- a/src/rest_framework_jwt/compat.py
+++ b/src/rest_framework_jwt/compat.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import sys
 
 from django import VERSION
+import jwt
 
 from .settings import api_settings
 
@@ -52,3 +53,24 @@ def set_cookie_with_token(response, name, token):
         params.update({'samesite': api_settings.JWT_AUTH_COOKIE_SAMESITE})
 
     response.set_cookie(name, token, **params)
+
+
+if jwt.__version__.startswith("2"):
+    jwt_version = 2
+    ExpiredSignature = jwt.ExpiredSignatureError    
+else:
+    jwt_version = 1
+    ExpiredSignature = jwt.ExpiredSignature
+
+def jwt_decode(token, key, verify=None, **kwargs):
+    if verify is not None:
+        if jwt_version == 1:
+            kwargs["verify"] = verify
+        else:
+            if "options" not in kwargs:
+                kwargs["options"] = {"verify_signature": verify}
+            else:
+                kwargs["options"]["verify_signature"] = verify
+    if jwt_version == 2 and "algorithms" not in kwargs:
+        kwargs["algorithms"] = ["HS256"]
+    return jwt.decode(token, key, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
     docs,manifest,
-    py{27,35,36,37}-dj111-drf{37,38,39}-pyjwt1-codecov
-    py{35,36,37}-dj20-drf{37,38,39}-pyjwt1-codecov
-    py{35,36,37}-dj21-drf{37,38,39,310}-pyjwt1-codecov
-    py{35,36,37}-dj22-drf{37,38,39,310}-pyjwt1-codecov
-    py{36,37,38}-dj30-drf{311}-pyjwt1-codecov
-    py{36,37,38}-dj30-drf{311}-pyjwt2-codecov
+    py{27,35,36,37}-dj111-drf{37,38,39}-pyjwt{1,2}-codecov
+    py{35,36,37}-dj20-drf{37,38,39}-pyjwt{1,2}-codecov
+    py{35,36,37}-dj21-drf{37,38,39,310}-pyjwt{1,2}-codecov
+    py{35,36,37}-dj22-drf{37,38,39,310}-pyjwt{1,2}-codecov
+    py{36,37,38}-dj30-drf{311}-pyjwt{1,2}-codecov
 
 [travis:env]
 TRAVIS =
@@ -35,7 +34,7 @@ deps =
     pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
     pyjwt1: cryptography==2.0.3 # Because that works so far!
     pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
-    pyjwt2: cryptography < 3.4 # Avoiding the "needs Rust" versions
+    pyjwt2: cryptography>=3,<3.4 # Avoiding the "needs Rust" versions
     coverage: coverage
     codecov: codecov
 # bash is used to create the codecov flags from the envname,

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
     docs,manifest,
-    py{27,35,36,37}-dj111-drf{37,38,39}-codecov
-    py{35,36,37}-dj20-drf{37,38,39}-codecov
-    py{35,36,37}-dj21-drf{37,38,39,310}-codecov
-    py{35,36,37}-dj22-drf{37,38,39,310}-codecov
-    py{36,37,38}-dj30-drf{311}-codecov
+    py{27,35,36,37}-dj111-drf{37,38,39}-pyjwt1-codecov
+    py{35,36,37}-dj20-drf{37,38,39}-pyjwt1-codecov
+    py{35,36,37}-dj21-drf{37,38,39,310}-pyjwt1-codecov
+    py{35,36,37}-dj22-drf{37,38,39,310}-pyjwt1-codecov
+    py{36,37,38}-dj30-drf{311}-pyjwt1-codecov
+    py{36,37,38}-dj30-drf{311}-pyjwt2-codecov
 
 [travis:env]
 TRAVIS =
@@ -31,12 +32,14 @@ deps =
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
+    pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
+    pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
     coverage: coverage
     codecov: codecov
 # bash is used to create the codecov flags from the envname,
 # only when codecov is used in the envname
 whitelist_externals =
-    /bin/bash,
+    /bin/bash
     /usr/bin/bash
 commands =
     pytest {posargs} --cov=rest_framework_jwt

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
 envlist =
     docs,manifest,
-    py{27,35,36,37}-dj111-drf{37,38,39}-pyjwt{1,2}-codecov
-    py{35,36,37}-dj20-drf{37,38,39}-pyjwt{1,2}-codecov
-    py{35,36,37}-dj21-drf{37,38,39,310}-pyjwt{1,2}-codecov
-    py{35,36,37}-dj22-drf{37,38,39,310}-pyjwt{1,2}-codecov
+    py{27,35}-dj111-drf{37,38,39}-pyjwt1-codecov
+    py{36,37}-dj111-drf{37,38,39}-pyjwt{1,2}-codecov
+    py35-dj20-drf{37,38,39}-pyjwt1-codecov
+    py{36,37}-dj20-drf{37,38,39}-pyjwt{1,2}-codecov
+    py35-dj21-drf{37,38,39,310}-pyjwt1-codecov
+    py{36,37}-dj21-drf{37,38,39,310}-pyjwt{1,2}-codecov
+    py35-dj22-drf{37,38,39,310}-pyjwt1-codecov
+    py{36,37}-dj22-drf{37,38,39,310}-pyjwt{1,2}-codecov
     py{36,37,38}-dj30-drf{311}-pyjwt{1,2}-codecov
 
 [travis:env]

--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,8 @@ deps =
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
-    pyjwt1: cryptography==2.0.3 # Because that works so far!
     pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
-    pyjwt2: cryptography>=3,<3.4 # Avoiding the "needs Rust" versions
+    cryptography<3.4 # Avoiding the "needs Rust" versions
     coverage: coverage
     codecov: codecov
 # bash is used to create the codecov flags from the envname,

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
+    pyjwt1: cryptography==2.0.3 # Because that works so far!
     pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
     coverage: coverage
     codecov: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
     pyjwt1: cryptography==2.0.3 # Because that works so far!
     pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
+    pyjwt2: cryptography < 3.4 # Avoiding the "needs Rust" versions
     coverage: coverage
     codecov: codecov
 # bash is used to create the codecov flags from the envname,


### PR DESCRIPTION
Fixes #88.

Adds PyJWT 2.x support in a backwards-compat way i.e. works with 1.x as well, and tests for it with tox.