### PR TITLE
Add to changelog a missing Breaking Change on v1.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,12 @@ Misc
 1.12.8 (2018-12-21)
 ====================
 
+Breaking Changes
+----------------
+
+- The default configuration of `JWT_AUTH_HEADER_PREFIX` was changed from `JWT` to `Bearer`. Add `"JWT_AUTH_HEADER_PREFIX": "JWT",` to your `JWT_AUTH` if want to keep the previous behavior.
+
+
 Misc
 ----
 


### PR DESCRIPTION
This pr document a missing Breaking Change on v1.12.8.

I was migrating a legacy project from `djangorestframework-jwt == 1.11.0` to this one and realized that this change was missing on changelog and also that it is very difficult to verify the difference between `djangorestframework-jwt` and this package, since apparently `git mv` was not used during directory refactoring and then the git history of `rest_framework_jwt/settings.py` was not preserved.

--
#### Pull-request sponsored by

[![image](https://s3-us-west-2.amazonaws.com/labcodes.com.br/lab/labcodes-328x120.png)](https://labcodes.com.br/)
