### PR TITLE
Stop showing whole JWT values for the 'blacklist' string representation

### DIFF
--- a/src/rest_framework_jwt/blacklist/models.py
+++ b/src/rest_framework_jwt/blacklist/models.py
@@ -36,7 +36,7 @@ class BlacklistedToken(models.Model):
     objects = BlacklistedTokenManager()
 
     def __str__(self):
-        return 'Blacklisted token - {} - {}'.format(self.user, self.token)
+        return 'Blacklisted token - {} - {}'.format(self.user, self.expires_at)
 
 
     @staticmethod

--- a/tests/models/test_blacklisted_token.py
+++ b/tests/models/test_blacklisted_token.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
 from datetime import timedelta
 from django.utils import timezone
 
@@ -100,3 +101,19 @@ def test_token_is_not_blocked_by_id_when_ids_disabled(user, monkeypatch):
     ).save()
 
     assert BlacklistedToken.is_blocked(token, payload) is False
+
+
+
+def test_token_has_expected_string_representation(user):
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+
+    expiration = datetime(2021, 11, 1, 12, 34, 56, 123456, tzinfo=timezone.utc)
+    banned_token = BlacklistedToken(
+        token=token,
+        token_id=payload['jti'],
+        expires_at=expiration,
+        user=user,
+    )
+
+    assert str(banned_token) == 'Blacklisted token - username - 2021-11-01 12:34:56.123456+00:00'


### PR DESCRIPTION
Avoid showing the whole token in the string representation.

These values are somewhat sensitive, so we should avoid showing them in places the barred token is shown as a string. (For example, when deleting a user via django-admin, the string representation is shown for the cascading deletion.)

The token value is also a little funny, as I made it nullable in a previous change (see PR #84).

All tokens will have an expiration, so it seems like a reasonable fact that will generally vary between tokens.

It's tempting to use the token_id, but since that is only conditionally present; I'm punting on it until we perhaps make token ids mandatory.