### PR TITLE
Fix buggy migration for 'blacklisted' token ids

### DIFF
--- a/changelog.d/94.bugfix.md
+++ b/changelog.d/94.bugfix.md
@@ -1,0 +1,1 @@
+Fix broken migration for 'blacklisted' token ids. The migration released in v1.18.0 would fail if you had any existing blacklisted tokens.

--- a/src/rest_framework_jwt/blacklist/migrations/0002_add_token_id.py
+++ b/src/rest_framework_jwt/blacklist/migrations/0002_add_token_id.py
@@ -11,7 +11,7 @@ def add_token_id_values(apps, schema_editor):
     """
     BlacklistedToken = apps.get_model('blacklist', 'BlacklistedToken')
     for row in BlacklistedToken.objects.filter(token_id=None):
-        payload = jwt.decode(row.token)
+        payload = jwt.decode(row.token, None, options={'verify_signature': False})
         token_id = payload.get('orig_jti') or payload.get('jti')
         if token_id:
             row.token_id = token_id


### PR DESCRIPTION
Fix decode call for migration.

I don't care about verifying the token value here; if it got as far as the database, it's reasonable to expect it was valid when it was inserted.

This was my mistake in Styria-Digital/django-rest-framework-jwt#84, which was released in v1.18.0, where I didn't test the migration properly with real data.