### PR TITLE
Added testing for Django 3.1,3.2 & DRF 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ envlist =
     py35-dj22-drf{37,38,39,310}-pyjwt1-codecov
     py{36,37}-dj22-drf{37,38,39,310}-pyjwt{1,2}-codecov
     py{36,37,38}-dj30-drf{311}-pyjwt{1,2}-codecov
+    py{36,37,38}-dj{30,31,32}-drf{311,312}-pyjwt{1,2}-codecov
+    py{39}-dj{30,31,32}-drf{311,312}-pyjwt{1,2}-codecov
 
 [travis:env]
 TRAVIS =
@@ -30,11 +32,14 @@ deps =
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
+    drf312: djangorestframework>=3.12,<3.13
     pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
     pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
     cryptography<3.4 # Avoiding the "needs Rust" versions


### PR DESCRIPTION
**- Added testing for Django 3.1,3.2 & DRF 3.12**

Tests are successfully running on fork, See https://github.com/mzulqarnain1/django-rest-framework-jwt/pull/1