### PR TITLE
Prevent hard check on token expiration when calling token refresh endpoint

### DIFF
--- a/src/rest_framework_jwt/serializers.py
+++ b/src/rest_framework_jwt/serializers.py
@@ -92,7 +92,7 @@ class RefreshAuthTokenSerializer(serializers.Serializer):
     def validate(self, data):
         token = data['token']
 
-        payload = check_payload(token=token)
+        payload = check_payload(token=token, verify_exp=False)
         user = check_user(payload=payload)
 
         # Get and check 'orig_iat'

--- a/src/rest_framework_jwt/utils.py
+++ b/src/rest_framework_jwt/utils.py
@@ -132,14 +132,14 @@ def jwt_encode_payload(payload):
     return enc
 
 
-def jwt_decode_token(token):
+def jwt_decode_token(token, verify_exp=api_settings.JWT_VERIFY_EXPIRATION):
     """Decode JWT token claims."""
 
     if jwt_version == 2 and type(token) == bytes:
         token = token.decode()
 
     options = {
-        'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
+        'verify_exp': verify_exp,
     }
 
     algorithms = api_settings.JWT_ALGORITHM
@@ -206,11 +206,11 @@ def jwt_create_response_payload(
     return {'pk': issued_at, 'token': token}
 
 
-def check_payload(token):
+def check_payload(token, *args, **kwargs):
     from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
     try:
-        payload = JSONWebTokenAuthentication.jwt_decode_token(token)
+        payload = JSONWebTokenAuthentication.jwt_decode_token(token, *args, **kwargs)
     except ExpiredSignature:
         msg = _('Token has expired.')
         raise serializers.ValidationError(msg)


### PR DESCRIPTION
The refresh endpoint shouldn't have a hard check on token expiration since we're allowing for tokens to be refreshed beyond the expiration up to a given delta. The current functionality prevents a refresh from ever occurring, causing the refresh endpoint to also respond with a 401, thus ending the user's session.

This fix bubbles `verify_exp=False` from the refresh serializer down to `jwt_decode` to prevent it from raising an `ExpiredSignature` exception when attempting to refresh an otherwise valid token, as allowed by the settings.

Fixes #25 