### PR TITLE
fix: Added Django 4.0, Python 3.10, and DRF 3.13 support

### DIFF
--- a/changelog.d/107.bugfix.md
+++ b/changelog.d/107.bugfix.md
@@ -1,0 +1,1 @@
+Fixed usage of deprecated functions for python 3.10, djangorestframework 3.13, and django 4.0

--- a/src/rest_framework_jwt/compat.py
+++ b/src/rest_framework_jwt/compat.py
@@ -20,7 +20,7 @@ except ImportError:
 try:
   from django.conf.urls import url
 except ImportError:
-  from django.urls import url
+  from django.urls import re_path as url
 
 
 if sys.version_info[0] == 2:

--- a/tests/views/test_authentication.py
+++ b/tests/views/test_authentication.py
@@ -7,7 +7,11 @@ from base64 import b64encode
 from collections import OrderedDict
 
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from jwt import get_unverified_header
 from jwt.exceptions import InvalidAlgorithmError, InvalidSignatureError, InvalidTokenError

--- a/tests/views/test_impersonation.py
+++ b/tests/views/test_impersonation.py
@@ -2,7 +2,11 @@
 
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from rest_framework import status
 from rest_framework.reverse import reverse

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ envlist =
     py{36,37}-dj22-drf{37,38,39,310}-pyjwt{1,2}-codecov
     py{36,37,38}-dj30-drf{311}-pyjwt{1,2}-codecov
     py{36,37,38}-dj{30,31,32}-drf{311,312}-pyjwt{1,2}-codecov
-    py{39}-dj{30,31,32}-drf{311,312}-pyjwt{1,2}-codecov
+    py{39,310}-dj{30,31,32}-drf{311,312,313}-pyjwt{1,2}-codecov
+    py{39,310}-dj40-drf313-pyjwt{1,2}-codecov
 
 [travis:env]
 TRAVIS =
@@ -34,12 +35,14 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
     pyjwt1: PyJWT[crypto]>=1.5.2,<2.0.0
     pyjwt2: PyJWT[crypto]>=2.0.0,<3.0.0
     cryptography<3.4 # Avoiding the "needs Rust" versions


### PR DESCRIPTION
- Updated to add support for newest versions of python and dependencies.
- Updated tox tests to include the new versions
- Removed deprecated functions