### PR TITLE
Bugfix: Ensure blacklist expires_at is set in a fully UTC context

### DIFF
--- a/changelog.d/114.bugfix.md
+++ b/changelog.d/114.bugfix.md
@@ -1,0 +1,1 @@
+Fixed BlacklistedTokenSerializer expires_at in non-UTC contexts

--- a/src/rest_framework_jwt/blacklist/serializers.py
+++ b/src/rest_framework_jwt/blacklist/serializers.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 
-from django.utils.timezone import make_aware
+from django.utils.timezone import make_aware, utc
 
 from rest_framework import serializers
 from rest_framework.exceptions import APIException
@@ -42,12 +42,16 @@ class BlacklistTokenSerializer(serializers.ModelSerializer):
         # the same original authentication event.
         token_id = payload.get('orig_jti') or payload.get('jti')
 
-        self.validated_data.update({
-            'token_id': token_id,
-            'user': check_user(payload),
-            'expires_at':
-                make_aware(datetime.utcfromtimestamp(expires_at_unix_time)),
-        })
+        self.validated_data.update(
+            {
+                'token_id': token_id,
+                'user': check_user(payload),
+                'expires_at': make_aware(
+                    datetime.utcfromtimestamp(expires_at_unix_time),
+                    timezone=utc,
+                ),
+            }
+        )
 
         # Don't store the token if we can rely on token IDs.
         # The token values are still sensitive until they expire.

--- a/tests/serializers/test_blacklisted_token_serializer.py
+++ b/tests/serializers/test_blacklisted_token_serializer.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from datetime import timedelta
+from django.conf import settings
+from django.utils import timezone
+
+import pytest
+
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+from rest_framework_jwt.blacklist.serializers import BlacklistTokenSerializer
+from rest_framework_jwt.settings import api_settings
+
+
+@pytest.mark.parametrize("id_setting", ["require", "include"])
+def test_token_expiration_is_saved_as_utc(user, monkeypatch, id_setting):
+    # temporarily change time zone
+    monkeypatch.setattr(settings, "TIME_ZONE", "Asia/Tokyo")
+    monkeypatch.setattr(api_settings, "JWT_TOKEN_ID", id_setting)
+    payload = JSONWebTokenAuthentication.jwt_create_payload(user)
+    token = JSONWebTokenAuthentication.jwt_encode_payload(payload)
+
+    # pass token through serializer to test expires_at validity
+    serializer = BlacklistTokenSerializer(data={"token": token})
+    serializer.is_valid()
+    bltoken = serializer.save()
+
+    # token expiry datetime should be UTC
+    assert bltoken.expires_at.tzinfo == timezone.utc
+    # token expiry datetime handling should all be UTC (iat, expires_at) even though local timezone is different
+    assert bltoken.expires_at == timezone.make_aware(
+        datetime.utcfromtimestamp(payload.get("iat"))
+        + timedelta(seconds=api_settings.JWT_EXPIRATION_DELTA.seconds),
+        timezone=timezone.utc,
+    )


### PR DESCRIPTION
This was found in a context where `UTC` was not the Django timezone, but rather `Asia/Tokyo`. I have added a test which replicates the issue.

# Before:

```
(Pdb) iat
1685329261
(Pdb) expires_at_unix_time
1685331061.0
(Pdb) datetime.utcfromtimestamp(iat)
datetime.datetime(2023, 5, 29, 3, 1, 1)
(Pdb) datetime.utcfromtimestamp(expires_at_unix_time)
datetime.datetime(2023, 5, 29, 3, 31, 1)
(Pdb) make_aware(datetime.utcfromtimestamp(expires_at_unix_time))
datetime.datetime(2023, 5, 29, 3, 31, 1, tzinfo=zoneinfo.ZoneInfo(key='Asia/Tokyo'))
```
iat (UTC)
expires_at_unix_time = iat + 30mins (UTC)
expires_at = iat + 30mins (Asia/Tokyo) → this means the token is created already expired!


# After:
```
(Pdb) iat
1685335304
(Pdb) expires_at_unix_time
1685940104.0
(Pdb) datetime.datetime.utcfromtimestamp(iat)
datetime.datetime(2023, 5, 29, 4, 41, 44)
(Pdb) datetime.datetime.utcfromtimestamp(expires_at_unix_time)
datetime.datetime(2023, 5, 29, 5, 11, 44)
(Pdb) make_aware(datetime.datetime.utcfromtimestamp(expires_at_unix_time),timezone=datetime.timezone.utc)
datetime.datetime(2023, 5, 29, 5, 11, 44, tzinfo=datetime.timezone.utc)
```
iat (UTC)
expires_at_unix_time = iat + 30mins (UTC)
expires_at = iat + 30mins (UTC)