### PR TITLE
Fix RemovedInDjango41Warning on `default_app_config`

### DIFF
--- a/src/rest_framework_jwt/blacklist/__init__.py
+++ b/src/rest_framework_jwt/blacklist/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'rest_framework_jwt.blacklist.apps.BlacklistedTokenConfig'
+import django
+
+if django.VERSION < (3, 2):
+  default_app_config = 'rest_framework_jwt.blacklist.apps.BlacklistedTokenConfig'


### PR DESCRIPTION
[Since Django 3.2](https://code.djangoproject.com/ticket/31180
), the property has been deprecated as it is automatically detected by Django. Currently when `django-rest-framework-jwt` is loaded into a Django 3.2+ project, it throws deprecation warnings

The pattern in this PR can be found in other libraries that need to support wide ranges of Django versions:
https://github.com/revsys/django-health-check/blob/master/health_check/db/__init__.py
